### PR TITLE
prevent main content column from expanding

### DIFF
--- a/src/content/post/markdown-elements.md
+++ b/src/content/post/markdown-elements.md
@@ -1,0 +1,117 @@
+---
+title: "A post of Markdown elements"
+description: "This post is for testing and listing a number of different markdown elements"
+publishDate: "22 Feb 2023"
+tags: ["test", "markdown"]
+---
+
+## This is a H2 Heading
+
+### This is a H3 Heading
+
+#### This is a H4 Heading
+
+##### This is a H5 Heading
+
+###### This is a H6 Heading
+
+## Horizontal Rules
+
+---
+
+---
+
+---
+
+## Emphasis
+
+**This is bold text**
+
+_This is italic text_
+
+~~Strikethrough~~
+
+## Blockquotes
+
+> Blockquotes can also be nested...
+>
+> > ...by using additional greater-than signs right next to each other...
+> >
+> > > ...or with spaces between arrows.
+
+## Lists
+
+Unordered
+
+- Create a list by starting a line with `+`, `-`, or `*`
+- Sub-lists are made by indenting 2 spaces:
+  - Marker character change forces new list start:
+    - Ac tristique libero volutpat at
+    - Facilisis in pretium nisl aliquet
+    - Nulla volutpat aliquam velit
+- Very easy!
+
+Ordered
+
+1. Lorem ipsum dolor sit amet
+2. Consectetur adipiscing elit
+3. Integer molestie lorem at massa
+
+4. You can use sequential numbers...
+5. ...or keep all the numbers as `1.`
+
+Start numbering with offset:
+
+57. foo
+1. bar
+
+## Code
+
+Inline `code`
+
+Indented code
+
+    // Some comments
+    line 1 of code
+    line 2 of code
+    line 3 of code
+
+Block code "fences"
+
+```
+Sample text here...
+```
+
+Syntax highlighting
+
+```js
+var foo = function (bar) {
+	return bar++;
+};
+
+console.log(foo(5));
+```
+
+## Tables
+
+| Option | Description                                                               |
+| ------ | ------------------------------------------------------------------------- |
+| data   | path to data files to supply the data that will be passed into templates. |
+| engine | engine to be used for processing templates. Handlebars is the default.    |
+| ext    | extension to be used for dest files.                                      |
+
+Right aligned columns
+
+| Option |                                                               Description |
+| -----: | ------------------------------------------------------------------------: |
+|   data | path to data files to supply the data that will be passed into templates. |
+| engine |    engine to be used for processing templates. Handlebars is the default. |
+|    ext |                                      extension to be used for dest files. |
+
+## Links
+
+[Content from markdown-it](https://markdown-it.github.io/)
+
+## Quotes
+
+"Double quotes" and 'single quotes'

--- a/src/content/post/missing-content.md
+++ b/src/content/post/missing-content.md
@@ -1,0 +1,6 @@
+---
+title: "This post doeesn't have any content"
+description: "This post is purely for testing the table of content, which should not be rendered"
+publishDate: "22 Feb 2023"
+tags: ["test", "toc"]
+---

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -38,8 +38,8 @@ const { headings } = await post.render();
 </script>
 
 <BaseLayout meta={{ title, description, articleDate, ogImage: socialImage }}>
-	<div class="sm:grid sm:grid-cols-[3fr_1fr] sm:items-start sm:gap-x-10">
-		<article class="break-words">
+	<div class="sm:grid sm:grid-cols-4 sm:items-start sm:gap-x-10">
+		<article class="sm:col-span-3 break-words">
 			<div id="blog-hero"><BlogHero content={post} /></div>
 			<div
 				class="prose prose-sm prose-cactus mt-12 prose-headings:font-semibold prose-headings:before:absolute prose-headings:before:-ml-4 prose-headings:before:text-accent prose-headings:before:content-['#'] prose-th:before:content-none"

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -41,7 +41,7 @@ const { headings } = await post.render();
 	<div class="flex items-start gap-x-10">
 		{
 			!!headings.length && (
-				<aside class="sticky top-20 order-2 hidden flex-shrink flex-grow-0 basis-64 lg:block">
+				<aside class="sticky top-20 order-2 -mr-32 hidden basis-64 lg:block">
 					<h2 class="font-semibold">Table of Contents</h2>
 					<ul class="mt-4 text-xs">
 						{headings.map(({ depth, slug, text }) => (
@@ -59,7 +59,7 @@ const { headings } = await post.render();
 				</aside>
 			)
 		}
-		<article class="flex-shrink flex-grow break-words">
+		<article class="flex-grow break-words">
 			<div id="blog-hero"><BlogHero content={post} /></div>
 			<div
 				class="prose prose-sm prose-cactus mt-12 prose-headings:font-semibold prose-headings:before:absolute prose-headings:before:-ml-4 prose-headings:before:text-accent prose-headings:before:content-['#'] prose-th:before:content-none"

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -38,8 +38,28 @@ const { headings } = await post.render();
 </script>
 
 <BaseLayout meta={{ title, description, articleDate, ogImage: socialImage }}>
-	<div class="sm:grid sm:grid-cols-4 sm:items-start sm:gap-x-10">
-		<article class="sm:col-span-3 break-words">
+	<div class="flex items-start gap-x-10">
+		{
+			!!headings.length && (
+				<aside class="sticky top-20 order-2 hidden flex-shrink flex-grow-0 basis-64 lg:block">
+					<h2 class="font-semibold">Table of Contents</h2>
+					<ul class="mt-4 text-xs">
+						{headings.map(({ depth, slug, text }) => (
+							<li class="line-clamp-2 hover:text-accent">
+								<a
+									class={`block ${depth <= 2 ? "mt-3" : "mt-2 pl-3 text-[0.6875rem]"}`}
+									href={`#${slug}`}
+									aria-label={`Scroll to section: ${text}`}
+								>
+									<span>{"#".repeat(depth)}</span> {text}
+								</a>
+							</li>
+						))}
+					</ul>
+				</aside>
+			)
+		}
+		<article class="flex-shrink flex-grow break-words">
 			<div id="blog-hero"><BlogHero content={post} /></div>
 			<div
 				class="prose prose-sm prose-cactus mt-12 prose-headings:font-semibold prose-headings:before:absolute prose-headings:before:-ml-4 prose-headings:before:text-accent prose-headings:before:content-['#'] prose-th:before:content-none"
@@ -47,20 +67,6 @@ const { headings } = await post.render();
 				<slot />
 			</div>
 		</article>
-		<aside class="hidden text-right sm:sticky sm:top-20 sm:block">
-			<h2 class="font-semibold">Table of Contents</h2>
-			<ul class="mt-4 space-y-2 text-xs">
-				{
-					headings.map(({ slug, text }) => (
-						<li class="line-clamp-2 hover:text-accent">
-							<a href={`#${slug}`} aria-label={`Scroll to section: ${text}`}>
-								<span>&#35;</span> {text}
-							</a>
-						</li>
-					))
-				}
-			</ul>
-		</aside>
 	</div>
 	<button
 		id="to-top-btn"


### PR DESCRIPTION
Changed the layout to 4 columns, as it is more readable and according to the documentation uses `minmax(0, 1fr)` under the bonnet
https://tailwindcss.com/docs/grid-template-columns

Fixes #53