### PR TITLE
Fix tags displaying 0 when there are no tags

### DIFF
--- a/src/pages/posts/[...page].astro
+++ b/src/pages/posts/[...page].astro
@@ -58,7 +58,7 @@ const paginationProps = {
 			<Pagination {...paginationProps} />
 		</section>
 		{
-			uniqueTags.length && (
+			uniqueTags.length > 0 && (
 				<aside>
 					<h2 class="mb-4 flex items-center text-lg font-semibold">
 						<svg

--- a/src/pages/posts/[...page].astro
+++ b/src/pages/posts/[...page].astro
@@ -58,7 +58,7 @@ const paginationProps = {
 			<Pagination {...paginationProps} />
 		</section>
 		{
-			uniqueTags.length > 0 && (
+			!!uniqueTags.length && (
 				<aside>
 					<h2 class="mb-4 flex items-center text-lg font-semibold">
 						<svg


### PR DESCRIPTION
If none of the posts have tags, the component will render 0 instead of nothing.

When there are no tags, nothing should be displayed.

Current
![Screenshot 2023-08-27 at 20 07 02](https://github.com/chrismwilliams/astro-theme-cactus/assets/24554998/834bbac0-25fb-46ea-bee2-8c56b1f46c0d)

Expected
![Screenshot 2023-08-27 at 20 06 45](https://github.com/chrismwilliams/astro-theme-cactus/assets/24554998/2b2f6d65-c014-434d-9b64-5d7413bb1038)
