### PR TITLE
feat: reduce initial css load

### DIFF
--- a/src/components/Search.astro
+++ b/src/components/Search.astro
@@ -1,9 +1,3 @@
----
-// Heavy inspiration taken from Astro Starlight -> https://github.com/withastro/starlight/blob/main/packages/starlight/components/Search.astro
-
-import "@pagefind/default-ui/css/ui.css";
----
-
 <site-search id="search" class="ms-auto">
 	<button
 		data-open-modal
@@ -115,6 +109,14 @@ import "@pagefind/default-ui/css/ui.css";
 						showSubResults: true,
 					});
 				});
+
+        onIdle(async () => {
+          const searchStyles = await import('../styles/search.css?inline');
+          const styleTag = document.createElement('style')
+          styleTag.id = "search";
+          styleTag.innerHTML = searchStyles.default || ''
+          document.head.appendChild(styleTag)
+        })
 			});
 
 			// close modal and clear input on view-transtion
@@ -129,65 +131,6 @@ import "@pagefind/default-ui/css/ui.css";
 
 	customElements.define("site-search", SiteSearch);
 </script>
-
-<style is:global>
-	:root {
-		--pagefind-ui-font: inherit;
-	}
-
-	#cactus__search .pagefind-ui__search-clear {
-		width: calc(60px * var(--pagefind-ui-scale));
-		padding: 0;
-		background-color: transparent;
-		overflow: hidden;
-	}
-	#cactus__search .pagefind-ui__search-clear:focus {
-		outline: 1px solid theme("colors.accent-2");
-	}
-	#cactus__search .pagefind-ui__search-clear::before {
-		content: "";
-		-webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' %3E%3Cpath stroke-linecap='round' stroke-linejoin='round' d='M6 18L18 6M6 6l12 12'%3E%3C/path%3E%3C/svg%3E")
-			center / 60% no-repeat;
-		mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' %3E%3Cpath stroke-linecap='round' stroke-linejoin='round' d='M6 18L18 6M6 6l12 12'%3E%3C/path%3E%3C/svg%3E")
-			center / 60% no-repeat;
-		background-color: theme("colors.accent");
-		display: block;
-		width: 100%;
-		height: 100%;
-	}
-
-	#cactus__search .pagefind-ui__result {
-		border: 0;
-	}
-
-	#cactus__search .pagefind-ui__result-link {
-		background-size: 100% 6px;
-		background-position: bottom;
-		background-repeat: repeat-x;
-		background-image: linear-gradient(
-			transparent,
-			transparent 5px,
-			theme("colors.textColor") 5px,
-			theme("colors.textColor")
-		);
-	}
-
-	#cactus__search .pagefind-ui__result-link:hover {
-		text-decoration: none;
-		background-image: linear-gradient(
-			transparent,
-			transparent 4px,
-			theme("colors.link") 4px,
-			theme("colors.link")
-		);
-	}
-
-	#cactus__search mark {
-		color: theme("colors.quote");
-		background-color: transparent;
-		font-weight: 600;
-	}
-</style>
 
 <style>
 	#cactus__search {

--- a/src/styles/search.css
+++ b/src/styles/search.css
@@ -1,0 +1,58 @@
+@import "@pagefind/default-ui/css/ui.css";
+
+:root {
+  --pagefind-ui-font: inherit;
+}
+
+#cactus__search .pagefind-ui__search-clear {
+  width: calc(60px * var(--pagefind-ui-scale));
+  padding: 0;
+  background-color: transparent;
+  overflow: hidden;
+}
+#cactus__search .pagefind-ui__search-clear:focus {
+  outline: 1px solid theme("colors.accent-2");
+}
+#cactus__search .pagefind-ui__search-clear::before {
+  content: "";
+  -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' %3E%3Cpath stroke-linecap='round' stroke-linejoin='round' d='M6 18L18 6M6 6l12 12'%3E%3C/path%3E%3C/svg%3E")
+  center / 60% no-repeat;
+  mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' %3E%3Cpath stroke-linecap='round' stroke-linejoin='round' d='M6 18L18 6M6 6l12 12'%3E%3C/path%3E%3C/svg%3E")
+  center / 60% no-repeat;
+  background-color: theme("colors.accent");
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+#cactus__search .pagefind-ui__result {
+  border: 0;
+}
+
+#cactus__search .pagefind-ui__result-link {
+  background-size: 100% 6px;
+  background-position: bottom;
+  background-repeat: repeat-x;
+  background-image: linear-gradient(
+    transparent,
+    transparent 5px,
+    theme("colors.textColor") 5px,
+    theme("colors.textColor")
+  );
+}
+
+#cactus__search .pagefind-ui__result-link:hover {
+  text-decoration: none;
+  background-image: linear-gradient(
+    transparent,
+    transparent 4px,
+    theme("colors.link") 4px,
+    theme("colors.link")
+  );
+}
+
+#cactus__search mark {
+  color: theme("colors.quote");
+  background-color: transparent;
+  font-weight: 600;
+}


### PR DESCRIPTION
<!-- Thank you for opening a PR and making this theme even better, I appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?

<!-- Delete any that don’t apply -->
- Reduce initial CSS load from 10.5KB to 7.9KB by lazy loading `@pagefind/default-ui/css/ui.css` and its customized CSS.

#### Description
- I moved the `@pagefind/default-ui/css/ui.css` and the `Search.astro`'s `<style is:global>` into `styles/search.css` and then lazy load the `styles/search.css` `onIdle`.

<!--
Here’s what will happen next:
Hopefully I'll get time soon after your pull request to take a look and may ask you to make changes.
I'll try to be responsive, but don’t worry if this takes a week or 2.
-->
