### PR TITLE
make it easy to see which blogs are in draft

### DIFF
--- a/src/components/blog/Hero.astro
+++ b/src/components/blog/Hero.astro
@@ -31,7 +31,10 @@ const dateTimeOptions: Intl.DateTimeFormatOptions = {
 		</div>
 	)
 }
-<h1 class="title mb-3 sm:mb-1">{data.title}</h1>
+{data.draft ? <span class="text-base text-red-500">(Draft)</span> : null}
+<h1 class="title mb-3 sm:mb-1">
+	{data.title}
+</h1>
 <div class="flex flex-wrap items-center gap-x-3 gap-y-2">
 	<p class="font-semibold">
 		<FormattedDate date={data.publishDate} dateTimeOptions={dateTimeOptions} /> /{" "}

--- a/src/components/blog/PostPreview.astro
+++ b/src/components/blog/PostPreview.astro
@@ -14,6 +14,7 @@ const postDate = post.data.updatedDate ?? post.data.publishDate;
 
 <FormattedDate date={postDate} class="min-w-[120px] text-gray-600 dark:text-gray-400" />
 <Tag>
+  {post.data.draft && <span class="text-red-500">(Draft) </span>}
 	<a href={`/posts/${post.slug}/`} class="cactus-link" data-astro-prefetch>
 		{post.data.title}
 	</a>


### PR DESCRIPTION
I think it's useful to see all blogs in draft status in an easier way while working on the page locally. Feel free to close if it's not relevant.

## Before

![image](https://github.com/chrismwilliams/astro-theme-cactus/assets/16299282/21733e74-0a82-4aa0-b437-73bb0b290886)

![image](https://github.com/chrismwilliams/astro-theme-cactus/assets/16299282/3addd3c9-437b-4e2f-8ef5-619caa88f05e)

![image](https://github.com/chrismwilliams/astro-theme-cactus/assets/16299282/90e77a73-6eed-4305-a093-2863575f1f9f)


## After

![image](https://github.com/chrismwilliams/astro-theme-cactus/assets/16299282/8f141e3e-0acf-4497-8cba-66e3e5fe0079)

![image](https://github.com/chrismwilliams/astro-theme-cactus/assets/16299282/079eff4f-a24f-4ec9-a3bb-57cc2fdaeb5c)

![image](https://github.com/chrismwilliams/astro-theme-cactus/assets/16299282/3ecba916-fd5f-4fa7-8787-258e395f81e5)

