### PR TITLE
fix: align social links horizontally

### DIFF
--- a/src/components/SocialList.astro
+++ b/src/components/SocialList.astro
@@ -1,7 +1,7 @@
 ---
 import { Icon } from "astro-icon/components";
 
-/** 
+/**
 	Uses https://www.astroicon.dev/getting-started/
 	Find icons via guide: https://www.astroicon.dev/guides/customization/#open-source-icon-sets
 	Only installed pack is: @iconify-json/mdi
@@ -20,7 +20,7 @@ const socialLinks: {
 ];
 ---
 
-<div class="flex flex-wrap items-end gap-x-2">
+<div class="flex items-center gap-x-2">
 	<p>Find me on</p>
 	<ul class="flex flex-1 items-center gap-x-2 sm:flex-initial">
 		{


### PR DESCRIPTION
<!-- Thank you for opening a PR and making this theme even better, I appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?

<!-- Delete any that don’t apply -->

- Minor fixes (css)

#### Description

Align social icons horizontally

Before: 
![image](https://github.com/chrismwilliams/astro-theme-cactus/assets/62394512/44843d02-a63c-4049-b450-ca2ae334219b)

After:
![image](https://github.com/chrismwilliams/astro-theme-cactus/assets/62394512/463cb28b-48ad-44ea-aef3-72e25ed8d21d)


<!--
Here’s what will happen next:
Hopefully I'll get time soon after your pull request to take a look and may ask you to make changes.
I'll try to be responsive, but don’t worry if this takes a week or 2.
-->
