### PR TITLE
Fix Default Selector for Code Themes

### DIFF
--- a/src/site.config.ts
+++ b/src/site.config.ts
@@ -68,7 +68,7 @@ export const expressiveCodeOptions: AstroExpressiveCodeOptions = {
 			if (theme === baseTheme || theme === altTheme) return `[data-theme='${theme.type}']`;
 		}
 		// return default selector
-		return `[data-theme="${theme.name}"]`;
+		return `[data-theme="${theme.type}"]`;
 	},
 	// One dark, one light theme => https://expressive-code.com/guides/themes/#available-themes
 	themes: ["dracula", "github-light"],


### PR DESCRIPTION
<!-- Thank you for opening a PR and making this theme even better, I appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?

<!-- Delete any that don’t apply -->

- Minor fixes (broken links, typos, css, etc.)

#### Description

Fixes a typo in the default theme selector for code syntax highlighting.