### PR TITLE
fix(layout/BlogPost): content full width when ToC hidden

### DIFF
--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -27,7 +27,7 @@ const { headings } = await post.render();
 		<article class="flex-grow break-words" data-pagefind-body>
 			<div id="blog-hero"><BlogHero content={post} /></div>
 			<div
-				class="prose prose-sm prose-cactus mt-12 prose-headings:font-semibold prose-headings:text-accent-2 prose-headings:before:absolute prose-headings:before:-ms-4 prose-headings:before:text-accent prose-headings:before:content-['#'] prose-th:before:content-none"
+				class="prose prose-sm prose-cactus mt-12 prose-headings:font-semibold prose-headings:text-accent-2 prose-headings:before:absolute prose-headings:before:-ms-4 prose-headings:before:text-accent prose-headings:before:content-['#'] prose-th:before:content-none max-w-full lg:max-w-[65ch]"
 			>
 				<slot />
 				<WebMentions />


### PR DESCRIPTION
#### What kind of changes does this PR include?
- Minor fixes (broken links, typos, css, etc.)

#### Description
- blog post content should be full width when ToC is hidden
- therefore, default should be max width, then at large screen breakpoint we limit width back to prose default of 65ch

| before (when screen small enough for ToC to be hidden, there is a gap where the ToC was shown previously)  | after (content now max width) |
| ------------- | ------------- |
| ![image](https://github.com/user-attachments/assets/b05c3dcd-8e9f-4783-9053-b367fbff9c7a)  | ![image](https://github.com/user-attachments/assets/86802912-49ee-4971-9af2-3bd6d144c417)  |


| before (when screen large, ToC shown) | after (no change) |
| ------------- | -------------- |
| ![image](https://github.com/user-attachments/assets/76437a0c-b194-472e-bd51-a4ae0e57fe97) | ![image](https://github.com/user-attachments/assets/194950c9-e02e-490a-88dc-ce31d90053a9) |

