### PR TITLE
Added Github card

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -13,6 +13,7 @@ import { siteConfig } from "./src/site.config";
 // Remark plugins
 import remarkDirective from "remark-directive"; /* Handle ::: directives as nodes */
 import { remarkAdmonitions } from "./src/plugins/remark-admonitions"; /* Add admonitions */
+import { remarkGithubCard } from "./src/plugins/remark-github-card";
 import { remarkReadingTime } from "./src/plugins/remark-reading-time";
 
 // Rehype plugins
@@ -86,7 +87,7 @@ export default defineConfig({
 			],
 			rehypeUnwrapImages,
 		],
-		remarkPlugins: [remarkReadingTime, remarkDirective, remarkAdmonitions],
+		remarkPlugins: [remarkReadingTime, remarkDirective, remarkGithubCard, remarkAdmonitions],
 		remarkRehype: {
 			footnoteLabelProperties: {
 				className: [""],

--- a/src/content/post/markdown-elements/extended-features.md
+++ b/src/content/post/markdown-elements/extended-features.md
@@ -1,0 +1,25 @@
+---
+title: "Markdown Extended Features"
+description: "This post showcases using the markdown admonition feature in Astro Cactus"
+publishDate: "12 4 2024"
+tags: ["markdown", "admonitions"]
+---
+
+## GitHub Repository Cards
+You can add dynamic cards that link to GitHub repositories, on page load, the repository information is pulled from the GitHub API.
+
+::github{repo="https://github.com/Fabrizz/MMM-OnSpotify"}
+
+You can also link a Github user:
+
+::github{repo="Fabrizz"}
+
+To use this feature you just use the "Github" directive:
+
+```markdown
+::github{repo="Fabrizz/MMM-OnSpotify"}
+::github{repo="https://github.com/Fabrizz"}
+
+::github{user="Fabrizz"}
+::github{user="https://github.com/Fabrizz"}
+```

--- a/src/plugins/remark-github-card.ts
+++ b/src/plugins/remark-github-card.ts
@@ -1,0 +1,152 @@
+import { type Properties, h as _h } from "hastscript";
+import type { Node, Paragraph as P, Root } from "mdast";
+import type { Directives } from "mdast-util-directive";
+import type { Plugin } from "unified";
+import { visit } from "unist-util-visit";
+
+const DIRECTIVE_NAME = "github"
+
+/** Checks if a node is a directive. */
+function isNodeDirective(node: Node): node is Directives {
+	return (
+		node.type === "containerDirective" ||
+		node.type === "leafDirective" ||
+		node.type === "textDirective"
+	);
+}
+
+/** From Astro Starlight: Function that generates an mdast HTML tree ready for conversion to HTML by rehype. */
+// biome-ignore lint/suspicious/noExplicitAny: <explanation>
+function h(el: string, attrs: Properties = {}, children: any[] = []): P {
+	const { properties, tagName } = _h(el, attrs);
+	return {
+		children,
+		data: { hName: tagName, hProperties: properties },
+		type: "paragraph",
+	};
+}
+
+export const remarkGithubCard: Plugin<[], Root> = () => (tree) => {
+	visit(tree, (node, index, parent) => {
+		if (!parent || index === undefined || !isNodeDirective(node)) return;
+
+		// We only want a leaf directive named DIRECTIVE_NAME
+		if (node.type !== "leafDirective" || node.name !== DIRECTIVE_NAME) return;
+		
+		let repoName = node.attributes?.repo ?? (node.attributes?.user ?? null);
+		if (!repoName) return; // Let the directive as-is if no repo is provided
+
+		repoName = repoName.endsWith('/') ? repoName.slice(0, -1) : repoName; // Remove trailing slash
+		repoName = repoName.startsWith('https://github.com/') ? repoName.replace("https://github.com/", "") : repoName; // Remove leading URL
+		
+		const repoParts = repoName.split('/');
+		const SimpleUUID = `GC${Math.random().toString(36).slice(-6)}` // Collisions are not important
+		const realUrl = 'https://github.com/' + repoName;
+
+		// If its a repo link
+		if (repoParts.length > 1) {
+			const script = h('script', {}, [{ type: 'text', value: `
+				fetch('https://api.github.com/repos/${repoName}', { referrerPolicy: "no-referrer" })
+					.then(response => response.json())
+					.then(data => {
+						const t = document.getElementById('${SimpleUUID}');
+						t.classList.remove("gh-loading");
+
+						if (data.description) {
+							t.querySelector('.gh-description').innerText = data.description.replace(/:[a-zA-Z0-9_]+:/g, '');
+						} else {
+							t.querySelector('.gh-description').style.display = 'none';
+						}
+						if (data.language) t.querySelector('.gh-language').innerText = data.language;
+        		t.querySelector('.gh-forks').innerText = Intl.NumberFormat('en-us', { notation: "compact", maximumFractionDigits: 1 }).format(data.forks).replaceAll("\u202f", '');
+        		t.querySelector('.gh-stars').innerText = Intl.NumberFormat('en-us', { notation: "compact", maximumFractionDigits: 1 }).format(data.stargazers_count).replaceAll("\u202f", '');
+						const avatarEl = t.querySelector('.gh-avatar');
+        		avatarEl.style.backgroundImage = 'url(' + data.owner.avatar_url + ')';
+        		avatarEl.style.backgroundColor = 'transparent';
+
+						if (data.license?.spdx_id) {
+							t.querySelector('.gh-license').innerText = data.license?.spdx_id
+						} else {
+							t.querySelector('.gh-license').style.display = 'none';
+						};
+					})
+				.catch(err => {
+        	document.getElementById('${SimpleUUID}').classList.add("gh-error")
+         	console.warn("[GITHUB-CARD] Error loading card for ${repoName} | ${SimpleUUID}.", err)
+      	})
+			`}]);
+
+			const hTitle = h("div", { class: "gh-title" }, [
+				h("span", { class: "gh-avatar" }),
+					h("span", { class: "gh-text" }, [
+						h("span", { class: "gh-user" }, [{type: 'text', value: repoParts[0] }]),
+						h("span", { class: "gh-divider" }, [{type: 'text', value: "/" }]),
+						h("span", { class: "gh-repo" }, [{type: 'text', value: repoParts[1] }]),
+					]),
+				h("span", { class: "gh-icon" }),
+				script,
+			]);
+
+			const hChips = h("div", { class: "gh-chips" }, [
+				h("span", { class: "gh-stars" }, [{type: 'text', value: "00K" }]),
+				h("span", { class: "gh-forks" }, [{type: 'text', value: "00K" }]),
+				h("span", { class: "gh-license"}, [{type: 'text', value: "MIT" }]),
+				h("span", { class: "gh-language" }, [{type: 'text', value: "" }]),
+			]);
+
+			const hDescription = h("div", { class: "gh-description" }, [
+				{type: 'text', value: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua." }
+			]);
+
+			parent.children.splice(index, 1, 
+				h('a', { id: SimpleUUID, class: 'github-card gh-loading', href: realUrl }, [
+					hTitle,
+					hDescription,
+					hChips,
+					script,
+				]
+			));
+		}
+			
+		// If its a user link
+		else if (repoParts.length === 1) {
+			const script = h('script', {}, [{ type: 'text', value: `
+				fetch('https://api.github.com/users/${repoName}', { referrerPolicy: "no-referrer" })
+					.then(response => response.json())
+					.then(data => {
+						const t = document.getElementById('${SimpleUUID}');
+						t.classList.remove("gh-loading");
+
+						const avatarEl = t.querySelector('.gh-avatar');
+        		avatarEl.style.backgroundImage = 'url(' + data.avatar_url + ')';
+        		avatarEl.style.backgroundColor = 'transparent';
+						t.querySelector('.gh-followers').innerText = Intl.NumberFormat('en-us', { notation: "compact", maximumFractionDigits: 1 }).format(data.followers).replaceAll("\u202f", '');
+						t.querySelector('.gh-repositories').innerText = Intl.NumberFormat('en-us', { notation: "compact", maximumFractionDigits: 1 }).format(data.public_repos).replaceAll("\u202f", '');
+						if (data.location) t.querySelector('.gh-region').innerText = data.location;
+
+					})
+				.catch(err => {
+        	const c = document.getElementById('${SimpleUUID}').classList.add("gh-error")
+         	console.warn("[GITHUB-CARD] Error loading card for ${repoName} | ${SimpleUUID}.", err)
+      	})
+			`}]);
+			
+			parent.children.splice(index, 1,
+				h('a', { id: SimpleUUID, class: 'github-card gh-simple gh-loading', href: realUrl }, [
+					h("div", { class: "gh-title" }, [
+						h("span", { class: "gh-avatar" }),
+						h("span", { class: "gh-text" }, [{type: 'text', value: repoParts[0] }]),
+						h("span", { class: "gh-icon" })
+					]),
+					h("div", { class: "gh-chips" }, [
+						h("span", { class: "gh-followers" }, [{type: 'text', value: "00K" }]),
+						h("span", { class: "gh-repositories" }, [{type: 'text', value: "00K" }]),
+						h("span", { class: "gh-region" }, [{type: 'text', value: "" }]),
+					]),
+					script,
+				])
+			);
+		}
+
+	});
+};

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -114,6 +114,111 @@ export default {
 						'th[align="left"], td[align="left"]': {
 							"text-align": "left",
 						},
+						/* Github Card */
+						".github-card": {
+							"@apply block bg-textColor/5 no-underline decoration-0 py-3 px-4 rounded-2xl transition-colors my-4": "",
+							".gh-title": {
+								"@apply flex items-center gap-3 text-[1rem] transition-colors": "",
+								".gh-avatar": {
+									"@apply w-6 h-6 rounded-full bg-textColor/20": "",
+									"background-image": "none",
+									"background-size": "cover",
+									"background-position": "center",
+								},
+								".gh-text": {
+									"@apply flex items-center gap-1 flex-1": "",
+									".gh-repo": {
+										"@apply font-semibold": "",
+									},
+								},
+								".gh-icon": {
+									"@apply w-6 h-6 bg-textColor transition-colors": "",
+									maskImage: `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='31' height='32' viewBox='0 0 496 512'%3E%3Cpath fill='%23a1f7cb' d='M165.9 397.4c0 2-2.3 3.6-5.2 3.6c-3.3.3-5.6-1.3-5.6-3.6c0-2 2.3-3.6 5.2-3.6c3-.3 5.6 1.3 5.6 3.6m-31.1-4.5c-.7 2 1.3 4.3 4.3 4.9c2.6 1 5.6 0 6.2-2s-1.3-4.3-4.3-5.2c-2.6-.7-5.5.3-6.2 2.3m44.2-1.7c-2.9.7-4.9 2.6-4.6 4.9c.3 2 2.9 3.3 5.9 2.6c2.9-.7 4.9-2.6 4.6-4.6c-.3-1.9-3-3.2-5.9-2.9M244.8 8C106.1 8 0 113.3 0 252c0 110.9 69.8 205.8 169.5 239.2c12.8 2.3 17.3-5.6 17.3-12.1c0-6.2-.3-40.4-.3-61.4c0 0-70 15-84.7-29.8c0 0-11.4-29.1-27.8-36.6c0 0-22.9-15.7 1.6-15.4c0 0 24.9 2 38.6 25.8c21.9 38.6 58.6 27.5 72.9 20.9c2.3-16 8.8-27.1 16-33.7c-55.9-6.2-112.3-14.3-112.3-110.5c0-27.5 7.6-41.3 23.6-58.9c-2.6-6.5-11.1-33.3 2.6-67.9c20.9-6.5 69 27 69 27c20-5.6 41.5-8.5 62.8-8.5s42.8 2.9 62.8 8.5c0 0 48.1-33.6 69-27c13.7 34.7 5.2 61.4 2.6 67.9c16 17.7 25.8 31.5 25.8 58.9c0 96.5-58.9 104.2-114.8 110.5c9.2 7.9 17 22.9 17 46.4c0 33.7-.3 75.4-.3 83.6c0 6.5 4.6 14.4 17.3 12.1C428.2 457.8 496 362.9 496 252C496 113.3 383.5 8 244.8 8M97.2 352.9c-1.3 1-1 3.3.7 5.2c1.6 1.6 3.9 2.3 5.2 1c1.3-1 1-3.3-.7-5.2c-1.6-1.6-3.9-2.3-5.2-1m-10.8-8.1c-.7 1.3.3 2.9 2.3 3.9c1.6 1 3.6.7 4.3-.7c.7-1.3-.3-2.9-2.3-3.9c-2-.6-3.6-.3-4.3.7m32.4 35.6c-1.6 1.3-1 4.3 1.3 6.2c2.3 2.3 5.2 2.6 6.5 1c1.3-1.3.7-4.3-1.3-6.2c-2.2-2.3-5.2-2.6-6.5-1m-11.4-14.7c-1.6 1-1.6 3.6 0 5.9c1.6 2.3 4.3 3.3 5.6 2.3c1.6-1.3 1.6-3.9 0-6.2c-1.4-2.3-4-3.3-5.6-2'/%3E%3C/svg%3E")`,
+									"mask-size": "contain",
+									"mask-position": "center",
+									"mask-repeat": "no-repeat",
+									"margin-right": "0px",
+								},
+							},
+							".gh-description": {
+								"@apply text-sm text-textColor/85 mt-2 leading-tight transition-colors": "",
+							},
+							".gh-chips": {
+								"@apply text-sm mt-3 flex gap-4": "",
+								"span.gh-stars, span.gh-forks, span.gh-license, span.gh-followers, span.gh-repositories": {
+									"&:before":{
+										"@apply inline-block overflow-visible bg-textColor transition-colors h-[1.3em] w-[1.3em] mr-[.4em] align-[-.24em]": "",
+										"content": "' '",
+										"mask-size": "contain",
+										"mask-position": "center",
+										"mask-repeat": "no-repeat",
+									}
+								},
+								".gh-stars": {
+									"&:before": {
+										"mask-image": `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' aria-hidden='true' height='16' viewBox='0 0 16 16' version='1.1' width='16'%3E%3Cpath d='M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.751.751 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Zm0 2.445L6.615 5.5a.75.75 0 0 1-.564.41l-3.097.45 2.24 2.184a.75.75 0 0 1 .216.664l-.528 3.084 2.769-1.456a.75.75 0 0 1 .698 0l2.77 1.456-.53-3.084a.75.75 0 0 1 .216-.664l2.24-2.183-3.096-.45a.75.75 0 0 1-.564-.41L8 2.694Z'%3E%3C/path%3E%3C/svg%3E")`
+									}
+								},
+								".gh-forks": {
+									"&:before": {
+										"mask-image": `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' aria-hidden='true' height='16' viewBox='0 0 16 16' version='1.1' width='16'%3E%3Cpath d='M5 5.372v.878c0 .414.336.75.75.75h4.5a.75.75 0 0 0 .75-.75v-.878a2.25 2.25 0 1 1 1.5 0v.878a2.25 2.25 0 0 1-2.25 2.25h-1.5v2.128a2.251 2.251 0 1 1-1.5 0V8.5h-1.5A2.25 2.25 0 0 1 3.5 6.25v-.878a2.25 2.25 0 1 1 1.5 0ZM5 3.25a.75.75 0 1 0-1.5 0 .75.75 0 0 0 1.5 0Zm6.75.75a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Zm-3 8.75a.75.75 0 1 0-1.5 0 .75.75 0 0 0 1.5 0Z'%3E%3C/path%3E%3C/svg%3E")`
+									}
+								},
+								".gh-license": {
+									"&:before": {
+										"@apply mr-[.6em]": "",
+										"mask-image": `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' aria-hidden='true' height='16' viewBox='0 0 16 16' version='1.1' width='16'%3E%3Cpath d='M8.75.75V2h.985c.304 0 .603.08.867.231l1.29.736c.038.022.08.033.124.033h2.234a.75.75 0 0 1 0 1.5h-.427l2.111 4.692a.75.75 0 0 1-.154.838l-.53-.53.529.531-.001.002-.002.002-.006.006-.006.005-.01.01-.045.04c-.21.176-.441.327-.686.45C14.556 10.78 13.88 11 13 11a4.498 4.498 0 0 1-2.023-.454 3.544 3.544 0 0 1-.686-.45l-.045-.04-.016-.015-.006-.006-.004-.004v-.001a.75.75 0 0 1-.154-.838L12.178 4.5h-.162c-.305 0-.604-.079-.868-.231l-1.29-.736a.245.245 0 0 0-.124-.033H8.75V13h2.5a.75.75 0 0 1 0 1.5h-6.5a.75.75 0 0 1 0-1.5h2.5V3.5h-.984a.245.245 0 0 0-.124.033l-1.289.737c-.265.15-.564.23-.869.23h-.162l2.112 4.692a.75.75 0 0 1-.154.838l-.53-.53.529.531-.001.002-.002.002-.006.006-.016.015-.045.04c-.21.176-.441.327-.686.45C4.556 10.78 3.88 11 3 11a4.498 4.498 0 0 1-2.023-.454 3.544 3.544 0 0 1-.686-.45l-.045-.04-.016-.015-.006-.006-.004-.004v-.001a.75.75 0 0 1-.154-.838L2.178 4.5H1.75a.75.75 0 0 1 0-1.5h2.234a.249.249 0 0 0 .125-.033l1.288-.737c.265-.15.564-.23.869-.23h.984V.75a.75.75 0 0 1 1.5 0Zm2.945 8.477c.285.135.718.273 1.305.273s1.02-.138 1.305-.273L13 6.327Zm-10 0c.285.135.718.273 1.305.273s1.02-.138 1.305-.273L3 6.327Z'%3E%3C/path%3E%3C/svg%3E")`
+									}
+								},
+								".gh-language, .gh-region ": {
+									"@apply flex-1 text-right text-textColor/80": "",
+								},
+								".gh-followers": {
+									"&:before": {
+										"mask-image": `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' text='muted' aria-hidden='true' height='16' viewBox='0 0 16 16' version='1.1' width='16'%3E%3Cpath d='M2 5.5a3.5 3.5 0 1 1 5.898 2.549 5.508 5.508 0 0 1 3.034 4.084.75.75 0 1 1-1.482.235 4 4 0 0 0-7.9 0 .75.75 0 0 1-1.482-.236A5.507 5.507 0 0 1 3.102 8.05 3.493 3.493 0 0 1 2 5.5ZM11 4a3.001 3.001 0 0 1 2.22 5.018 5.01 5.01 0 0 1 2.56 3.012.749.749 0 0 1-.885.954.752.752 0 0 1-.549-.514 3.507 3.507 0 0 0-2.522-2.372.75.75 0 0 1-.574-.73v-.352a.75.75 0 0 1 .416-.672A1.5 1.5 0 0 0 11 5.5.75.75 0 0 1 11 4Zm-5.5-.5a2 2 0 1 0-.001 3.999A2 2 0 0 0 5.5 3.5Z'%3E%3C/path%3E%3C/svg%3E")`
+									}
+								},
+								".gh-repositories": {
+									"&:before": {
+										"mask-image": `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' aria-hidden='true' height='16' viewBox='0 0 16 16' version='1.1' width='16'%3E%3Cpath d='M2 2.5A2.5 2.5 0 0 1 4.5 0h8.75a.75.75 0 0 1 .75.75v12.5a.75.75 0 0 1-.75.75h-2.5a.75.75 0 0 1 0-1.5h1.75v-2h-8a1 1 0 0 0-.714 1.7.75.75 0 1 1-1.072 1.05A2.495 2.495 0 0 1 2 11.5Zm10.5-1h-8a1 1 0 0 0-1 1v6.708A2.486 2.486 0 0 1 4.5 9h8ZM5 12.25a.25.25 0 0 1 .25-.25h3.5a.25.25 0 0 1 .25.25v3.25a.25.25 0 0 1-.4.2l-1.45-1.087a.249.249 0 0 0-.3 0L5.4 15.7a.25.25 0 0 1-.4-.2Z'%3E%3C/path%3E%3C/svg%3E")`
+									}
+								},
+							},
+							"&:hover": {
+								"@apply bg-textColor/10": "",
+								".gh-title": {
+									"@apply text-accent": "",
+								}
+							},
+							"&:active": {
+								"@apply scale-[0.98]": "",
+							},
+
+						},
+						".github-card.gh-simple": {
+							".gh-text": {
+								"@apply font-semibold": "",
+							},
+						},
+						".github-card.gh-loading": {
+							".gh-title .gh-avatar, .gh-title .gh-text, .gh-description, .gh-chips span": {
+								"@apply animate-pulse text-transparent bg-textColor/50 rounded-xl": "",
+							},
+							".gh-title .gh-avatar": {
+								"background-image": "none",
+							},
+							".gh-chips span": {
+								"&:before": {
+									"mask-image": "none !important",
+									"background-color": "transparent !important",
+								},
+							}
+						},
+						".github-card.gh-error": {
+							".gh-chips, .gh-description, .gh-avatar": {
+								"@apply hidden": "",
+							}
+						},
 						/* Admonitions/Aside */
 						".aside": {
 							"--admonition-color": "var(--tw-prose-quotes)",


### PR DESCRIPTION
<!-- Thank you for opening a PR and making this theme even better, I appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
- Added a Github Card (`::github{repo="chrismwilliams/astro-theme-cactus"` leaf directive) https://talk.commonmark.org/t/generic-directives-plugins-syntax/444#:~:text=2.%20Leaf%20Block%20Directives

#### Description
- Added the remark plugin to handle leaf directives for the Github card. (Using the refractored `remark-admonitions.ts` as a template, no new deps)
- Added the css to handle the card + inlined the icons
- The card loads with a pulsating skeleton, when the content is fetched it gets populated. If it cant reach the Github API (connection, rete-limit, etc) only the title/link is shown.
- Automatically converts a link or just the username/repo.
<img width="335" alt="image" src="https://github.com/user-attachments/assets/1a434b7c-948c-44ed-b611-acf32256da19">

