### PR TITLE
ensure that the frontmatter code snippets work in mdx files

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,5 +16,8 @@
 		"editor.wordWrap": "on"
 	},
 	"typescript.tsdk": "node_modules/typescript/lib",
-	"astro.content-intellisense": true
+	"astro.content-intellisense": true,
+	"files.associations": {
+		"*.mdx": "markdown"
+	}
 }


### PR DESCRIPTION
This is mainly a convenience update. It ensures mdx files are treated as markdown by VSCode without doing anything [extra](https://stackoverflow.com/questions/29973619/how-to-associate-a-file-extension-with-a-certain-language-in-vs-code) on the user end.