### PR TITLE
fix: remove unexpected semicolon

### DIFF
--- a/src/site.config.ts
+++ b/src/site.config.ts
@@ -50,7 +50,7 @@ export const expressiveCodeOptions: AstroExpressiveCodeOptions = {
 	styleOverrides: {
 		borderRadius: "4px",
 		codeFontFamily:
-			'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;',
+			'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
 		codeFontSize: "0.875rem",
 		codeLineHeight: "1.7142857rem",
 		codePaddingInline: "1rem",


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Minor fixes (broken links, typos, css, etc.)

#### Description

Removes an unexpected semicolon.

While trying to update the dependencies to the latest version, I always got an unexpected semicolon error (crashing any site with a ``` code block). After a long debugging session, I found the culprit. If you look at the `codeFontFamily` section [in the docs](https://expressive-code.com/reference/style-overrides/), there is no semicolon.

This change allows you to update all the packages to the latest version (at the time of writing). Updating seems to work on my local branch, but I didn't include it here since you might have other reasons not to update. 

Thank you for the theme! I hope this saves you some headaches.