### PR TITLE
Improvement: Load title from config

### DIFF
--- a/src/components/layout/Footer.astro
+++ b/src/components/layout/Footer.astro
@@ -9,7 +9,7 @@ const year = new Date().getFullYear();
 >
 	<div class="me-0 sm:me-4">
 		&copy; {siteConfig.author}
-		{year}.<span class="inline-block">&nbsp;🚀&nbsp;Astro Cactus</span>
+		{year}.<span class="inline-block">&nbsp;🚀&nbsp;{siteConfig.title}</span>
 	</div>
 	<nav
 		aria-labelledby="footer_links"

--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -2,6 +2,7 @@
 import Search from "@/components/Search.astro";
 import ThemeToggle from "@/components/ThemeToggle.astro";
 import { menuLinks } from "@/site.config";
+import {siteConfig} from "../../site.config";
 ---
 
 <header class="group relative mb-28 flex items-center sm:ps-18" id="main-header">
@@ -31,7 +32,7 @@ import { menuLinks } from "@/site.config";
 					fill="#53C68C"></path>
 				<path d="M45.334 240 0 213.334v120L45.334 360V240Z" fill="#B04304"></path>
 			</svg>
-			<span class="text-xl font-bold sm:text-2xl">Astro Cactus</span>
+			<span class="text-xl font-bold sm:text-2xl">{siteConfig.title}</span>
 		</a>
 		<nav
 			aria-label="Main menu"

--- a/src/site.config.ts
+++ b/src/site.config.ts
@@ -19,8 +19,13 @@ export const siteConfig: SiteConfig = {
 	lang: "en-GB",
 	// Meta property, found in src/components/BaseHead.astro L:42
 	ogLocale: "en_GB",
-	// Used to construct the meta title property found in src/components/BaseHead.astro L:11, and webmanifest name found in astro.config.ts L:42
-	title: "Astro Theme Cactus",
+	/* 
+		- Used to construct the meta title property found in src/components/BaseHead.astro L:11 
+		- The webmanifest name found in astro.config.ts L:42
+		- The link value found in src/components/layout/Header.astro L:35
+		- In the footer found in src/components/layout/Footer.astro L:12
+	*/
+	title: "Astro Cactus",
 	// ! Please remember to replace the following site property with your own domain, used in astro.config.ts
 	url: "https://astro-cactus.chriswilliams.dev/",
 };


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Improve convenience for users that fork / use this template.

#### Description

This PR reads the title set in the config file.
Instead of manually having to update the text, the title is retrieved from the config file, which is the most probable wanted result anyway.
**This does not lead to any visual changes.** 
In this case the text is a bit different though: It changes from `Astro Cactus` to `Astro Theme Cactus`.

If you want to have a different text than `siteConfig.title`, I suggest adding another property instead, e.g. `siteConfig.header` or `siteConfig.headerTitle`.

**Before** 

<img width="720" alt="Screenshot 2025-04-18 at 16 06 35" src="https://github.com/user-attachments/assets/77bc52fd-ecdb-490c-b6e9-93100805855e" />


**After**

<img width="720" alt="Screenshot 2025-04-18 at 16 06 16" src="https://github.com/user-attachments/assets/e804ab33-7eae-48ce-977b-dd74f529ec6b" />
