### PR TITLE
support for custom intros on tag pages

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -45,4 +45,12 @@ const note = defineCollection({
 	}),
 });
 
-export const collections = { post, note };
+const tag = defineCollection({
+	loader: glob({ base: "./src/content/tag", pattern: "**/*.{md,mdx}" }),
+	schema: z.object({
+		title: z.string().optional(),
+		description: z.string().optional(),
+	}),
+});
+
+export const collections = { post, note, tag };

--- a/src/content/tag/image.md
+++ b/src/content/tag/image.md
@@ -1,0 +1,7 @@
+---
+description: Learn about image handling in Astro Theme Cactus
+---
+
+This is an example of a custom intro on a tag page. Its markdown can be found in `src/content/tag/image.md`.
+
+Posts tagged with "image" demonstrate various image-related features including cover images, social media cards, and image optimization.

--- a/src/content/tag/markdown.md
+++ b/src/content/tag/markdown.md
@@ -1,0 +1,8 @@
+---
+title: Markdown Features
+description: Posts showcasing markdown and MDX capabilities
+---
+
+This is an example of a custom intro on a tag page. Its markdown can be found in `src/content/tag/markdown.md`.
+
+This tag includes posts that demonstrate the markdown processing capabilities of this theme.

--- a/src/content/tag/test.md
+++ b/src/content/tag/test.md
@@ -1,0 +1,15 @@
+---
+title: Test Posts
+description: These posts are used for testing various features of the theme.
+---
+
+This is an example of a custom intro on a tag page. Its markdown can be found in `src/content/tag/test.md`.
+
+This collection includes posts that demonstrate and test different features of the Astro Theme Cactus, including:
+
+- Markdown rendering capabilities
+- Image handling and optimization
+- Table of contents generation
+- Various edge cases and scenarios
+
+Feel free to explore these posts to understand how the theme handles different content types and configurations.

--- a/src/data/post.ts
+++ b/src/data/post.ts
@@ -7,6 +7,19 @@ export async function getAllPosts(): Promise<CollectionEntry<"post">[]> {
 	});
 }
 
+/** Get tag metadata by tag name */
+export async function getTagMeta(tag: string): Promise<CollectionEntry<"tag"> | undefined> {
+	try {
+		const tagEntries = await getCollection("tag", (entry) => {
+			return entry.id === tag;
+		});
+		return tagEntries[0];
+	} catch (error) {
+		console.error(`Error fetching tag metadata for ${tag}:`, error);
+		return undefined;
+	}
+}
+
 /** groups posts by year (based on option siteConfig.sortPostsByUpdatedDate), using the year as the key
  *  Note: This function doesn't filter draft posts, pass it the result of getAllPosts above to do so.
  */

--- a/src/pages/tags/[tag]/[...page].astro
+++ b/src/pages/tags/[tag]/[...page].astro
@@ -1,8 +1,8 @@
 ---
-import type { CollectionEntry } from "astro:content";
+import { type CollectionEntry, render } from "astro:content";
 import Pagination from "@/components/Paginator.astro";
 import PostPreview from "@/components/blog/PostPreview.astro";
-import { getAllPosts, getUniqueTags } from "@/data/post";
+import { getAllPosts, getUniqueTags, getTagMeta } from "@/data/post";
 import PageLayout from "@/layouts/Base.astro";
 import { collectionDateSort } from "@/utils/date";
 import type { GetStaticPaths, Page } from "astro";
@@ -28,9 +28,12 @@ interface Props {
 const { page } = Astro.props;
 const { tag } = Astro.params;
 
+const tagMeta = await getTagMeta(tag as string);
+const TagContent = tagMeta ? (await render(tagMeta)).Content : null;
+
 const meta = {
-	description: `View all posts with the tag - ${tag}`,
-	title: `Tag: ${tag}`,
+	description: tagMeta?.data.description ?? `View all posts with the tag - ${tag}`,
+	title: tagMeta?.data.title ?? `Tag: ${tag}`,
 };
 
 const paginationProps = {
@@ -56,6 +59,20 @@ const paginationProps = {
 		<span aria-hidden="true" class="ms-2 me-3 text-xl">→</span>
 		<span aria-hidden="true" class="text-xl">#{tag}</span>
 	</div>
+	{
+		tagMeta && tagMeta.data.description && (
+			<div class="mb-8 prose prose-sm prose-cactus">
+				<p class="text-text/80">{tagMeta.data.description}</p>
+			</div>
+		)
+	}
+	{
+		TagContent && (
+			<div class="mb-8 prose prose-cactus">
+				<TagContent />
+			</div>
+		)
+	}
 	<section aria-labelledby={`tags-${tag}`}>
 		<h2 id={`tags-${tag}`} class="sr-only">Post List</h2>
 		<ul class="space-y-6">


### PR DESCRIPTION
<!-- Thank you for opening a PR and making this theme even better, I appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?

Adds support for custom intros on tag pages.

#### Description

- Closes #354 <!-- Add an issue number if this PR will close it. -->
- This PR implements the ability to add custom introductory text to tag pages. Users can now create markdown files in `src/content/tag/` to provide context and descriptions for each tag.

![CleanShot 2025-05-23 at 11 27 28@2x](https://github.com/user-attachments/assets/db93959f-43ab-4430-b820-681d24e74700)

## Implementation Details

1. **Added new `tag` content collection** (`src/content.config.ts`)
   - Schema includes optional `title` and `description` fields
   - Supports both `.md` and `.mdx` files

2. **Added `getTagMeta()` function** (`src/data/post.ts`)
   - Retrieves tag metadata by tag name
   - Returns the corresponding tag content entry if it exists

3. **Updated tag page template** (`src/pages/tags/[tag]/[...page].astro`)
   - Fetches tag metadata for the current tag
   - Displays custom title and description if provided
   - Renders markdown content if present
   - Falls back to default title/description when no custom content exists

4. **Added example tag descriptions**
   - `src/content/tag/test.md` - Description for the "test" tag
   - `src/content/tag/markdown.md` - Description for the "markdown" tag  
   - `src/content/tag/image.md` - Description for the "image" tag

## Usage

To add a custom intro for a tag:

1. Create a markdown file in `src/content/tag/` with the same name as the tag (e.g., `example.md` for the "example" tag)
2. Add frontmatter with optional `title` and `description` fields
3. Add markdown content below the frontmatter for extended descriptions

Example:
```markdown
---
title: Custom Tag Title
description: Brief description shown in meta tags
---

Extended markdown content that appears at the top of the tag page.
This can include lists, links, and other markdown elements.
```

<!--
Here’s what will happen next:
Hopefully I'll get time soon after your pull request to take a look and may ask you to make changes.
I'll try to be responsive, but don’t worry if this takes a week or 2.
-->
