### PR TITLE
Fix typo and add deployment action for deployment to VPS via rsync/ssh

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,94 @@
+name: "Deploy artefact"
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  confirm-deployment-necessary:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: "Check out repository"
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: "Analyse for changes in the artefact"
+        id: analyse
+        run: |
+          git fetch origin refs/heads/main
+          DIFF=$(git diff origin/main -- './*' ':(exclude)./.github/*')
+          if [[ -n "$DIFF" ]]; then
+            echo "Changes outside of .github detected, deployment will proceed."
+            echo "deploy=true" >> $GITHUB_OUTPUT
+          else
+            echo "No changes outside of .github detected, deployment will not proceed."
+            echo "deploy=false" >> $GITHUB_OUTPUT
+          fi
+    outputs:
+      deploy: ${{ steps.analyse.outputs.deploy }}
+
+  deploy:
+    needs: confirm-deployment-necessary
+    if: needs.confirm-deployment-necessary.outputs.deploy == 'true'
+    runs-on: ubuntu-latest
+    environment: PROD
+
+    steps:
+      - name: "Check out repository"
+        uses: actions/checkout@v4
+
+      - name: "Install node"
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          registry-url: 'https://npm.pkg.github.com'
+
+      - name: "Install pnpm"
+        uses: pnpm/action-setup@v4
+        with:
+          version: 8.6.1
+          run_install: false
+
+      - name: "Get pnpm store directory"
+        shell: bash
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+      - name: "Set up pnpm cache"
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: "Install dependencies"
+        run: pnpm install
+
+      - name: "Build artefact"
+        run: pnpm build
+
+      - name: "Prepare secrets for ssh connection and execute deployment"
+        env:
+          DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}
+          SSH_PASS: ${{ secrets.SSH_PASS }}
+          USER: ${{ vars.REMOTE_USER }}
+          HOST: ${{ secrets.REMOTE_HOST }}
+          DIR: ${{ vars.REMOTE_DIR }}
+        run: |
+          mkdir -p ~/.ssh
+          echo "$DEPLOY_KEY" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan -t ed25519, "$HOST" >> ~/.ssh/known_hosts
+          eval "$(ssh-agent -s)"
+          echo "$SSH_PASS" | ssh-add <(echo "$DEPLOY_KEY")
+          rsync -avzr -e 'ssh -o StrictHostKeyChecking=no -v' --delete ./dist/ "${USER}"@"${HOST}":/var/www/html/"${DIR}"
+
+      - name: "Archive artefact"
+        uses: actions/upload-artifact@v4
+        if: github.ref == 'refs/heads/main'
+        with:
+          name: astro-theme-cactus
+          retention-days: 7
+          path: ${{ github.workspace }}/dist

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -68,7 +68,7 @@ jobs:
       - name: "Build artefact"
         run: pnpm build
 
-      - name: "Prepare secrets for ssh connection and execute deployment"
+      - name: "Prepare for ssh connection and execute deployment"
         env:
           DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}
           SSH_PASS: ${{ secrets.SSH_PASS }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,7 +42,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 18
-          registry-url: 'https://npm.pkg.github.com'
+          registry-url: "https://npm.pkg.github.com"
 
       - name: "Install pnpm"
         uses: pnpm/action-setup@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,7 +33,6 @@ jobs:
     needs: confirm-deployment-necessary
     if: needs.confirm-deployment-necessary.outputs.deploy == 'true'
     runs-on: ubuntu-latest
-    environment: PROD
 
     steps:
       - name: "Check out repository"

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Adding a post/note/tag is as simple as adding your .md(x) files to either `src/c
 
 The Tag collection allows you to override the content for generated tag pages. For example the template includes `src/content/tag/test.md` which overrides the content shown in `your-domain.com/tags/test`.
 
-> **Note**  
+> **Note**
 > For a tag page to work, the file name (`src/content/tag/*`) must also be in a post's [tags frontmatter.](#post-frontmatter)
 
 The posts/notes/tags included with this template are there as an example of how to structure your frontmatter. Additionally, the [Astro docs](https://docs.astro.build/en/guides/markdown-content/) has a detailed section on markdown pages.
@@ -179,7 +179,7 @@ You may be asked to included a snippet inside the **HEAD** tag of your website w
 
 [Astro docs](https://docs.astro.build/en/guides/deploy/) has a great section and breakdown of how to deploy your own Astro site on various platforms and their idiosyncrasies.
 
-By default the site will be built (see [Commands](#commands) section above) to a `/dist` directory.
+By default, the site will be built (see [Commands](#commands) section above) to a `/dist` directory.
 
 ## Acknowledgment
 

--- a/src/content/note/welcome.md
+++ b/src/content/note/welcome.md
@@ -6,4 +6,4 @@ publishDate: "2024-10-14T11:23:00Z"
 
 Hi, Hello. This is an example note feature included with Astro Cactus.
 
-They're for shorter, concise "post's" that you'd like to share, they generally don't include headings, but hey, that's entirely up to you.
+They're for shorter, concise 'posts' that you'd like to share. They generally don't include headings, but hey, that's entirely up to you.


### PR DESCRIPTION
#### What kind of changes does this PR include?

##### Minor fixes: 
Two or three typos

##### Changes with larger consequences: 
I added a GitHub Action that automatically is triggered on merges into the `main` branch or manually.

#### Description

The actions executes the following steps:

1. Check whether there were changes to the artefact (changes on actions do not require a deployment)
2. It will then build the artefact
3. The next step (`"Prepare for ssh connection and execute deployment"`) is the actual deployment via `rsync`:
   * Prepare the ssh (PRIVATE!) key on the ubuntu runner in .ssh
   * Add the IP address to known_hosts
   * Launch ssh agent
   * Add SSH key to agent (including the password)
   * Connect via rsync and copy the artefact in `./dist/` into the configured directory on the VPS
4. Archive the artefact for seven days if the deployment was executed with the main branch. It is possible to manually trigger deployments of other branches, but I feel those do not deserve to be archived.

The secrets/variables are stored in GitHub in two places:
1. Secrets are stored as repository secret:
  * `DEPLOY_KEY`: SSH Private Key
  * `SSH_PASS`: Passphrase for the SSH Key
  * `REMOTE_HOST`: IP address of the VPS (doesn't have to be a secret, I can change this to a variable is requested)

<img width="600" alt="Screenshot 2025-06-25 at 21 47 36" src="https://github.com/user-attachments/assets/8a9c0f1c-015a-4246-acda-540d913287ba" />

2. Variable are stored as repository variables:
 * `REMOTE_DIR`: The name of the directory into which the artefact is to be deployed. I am using CaddyServer, but AFAIK this is identical for any webserver. If requested, I will adapt the action, so the whole path is stored in the varible
`rsync -avzr -e 'ssh -o StrictHostKeyChecking=no -v' --delete ./dist/ "${USER}"@"${HOST}":/var/www/html/"${DIR}"` becomes `rsync -avzr -e 'ssh -o StrictHostKeyChecking=no -v' --delete ./dist/ "${USER}"@"${HOST}":"${DIR}"`
 * `REMOTE_USER`: The name of the user that connects via ssh. Could be `ssh root@<IP>` or `user@<IP>` - whatever is configured on the VPS.

<img width="600" alt="Screenshot 2025-06-25 at 21 47 43" src="https://github.com/user-attachments/assets/e5ef82a9-2fa5-451d-ab33-c9d4d8aa6cdc" />

### There are still some open points to discuss or add in this pull request:
* Do you even want this? If no, just reject this PR, of course.
* Documentation (Maybe in README.md maybe somewhere else
* Changes in the action (e.g. configuration of "${DIR}"


I know it is much. Maybe you do not even need this. My motivation was, that I do not use netlify. Instead I always manually deployed via script in my `package.json` using `rsync`. Since I wanted to automate this, I added this action. I appreciate your honest feedback