### PR TITLE
fix(nav):correct element positioning on mobile view Adjusted styles a…

### DIFF
--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -27,7 +27,7 @@ import {siteConfig} from "../../site.config";
 		</a>
 		<nav
 			aria-label="Main menu"
-			class="bg-global-bg/85 text-accent sm:divide-accent absolute -inset-x-4 top-14 hidden flex-col items-end gap-y-4 rounded-md py-4 shadow backdrop-blur-sm group-[.menu-open]:z-50 group-[.menu-open]:flex sm:static sm:z-auto sm:-ms-4 sm:mt-1 sm:flex sm:flex-row sm:items-center sm:divide-x sm:rounded-none sm:bg-transparent sm:py-0 sm:shadow-none sm:backdrop-blur-none"
+			class="bg-global-bg/85 text-accent sm:divide-accent absolute -inset-x-4 top-14 hidden flex-col items-center gap-y-4 rounded-md py-4 shadow backdrop-blur-sm group-[.menu-open]:z-50 group-[.menu-open]:flex sm:static sm:z-auto sm:-ms-4 sm:mt-1 sm:flex sm:flex-row sm:items-center sm:divide-x sm:rounded-none sm:bg-transparent sm:py-0 sm:shadow-none sm:backdrop-blur-none"
 			id="navigation-menu"
 		>
 			{


### PR DESCRIPTION
## 📄 Description  
Fixed the positioning of navigation elements on mobile devices.  
Now the items align correctly with consistent spacing and responsiveness across breakpoints.  

---

## 📝 Change summary  
- Adjusted nav styles for proper alignment on small screens  
- Fixed spacing and positioning inconsistencies  
- Improved overall mobile responsiveness of the navigation bar  

---

## 📝 Types of changes  
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)  
- [ ] 🚨 Breaking change  
- [ ] ✨ New feature  
- [ ] ⏫ Version upgrade  
- [ ] 🧹 Refactor  
- [ ] 📝 Documentation  

---

## 🧪 How to test  
1. Open the app on a mobile device or enable responsive mode in DevTools  
2. Inspect the navigation bar elements  
3. Verify that items are aligned correctly with proper spacing  
4. Test across different breakpoints to confirm consistent positioning  

---

## 📸 Screenshots  

### Before  
<img width="380" height="543" alt="image" src="https://github.com/user-attachments/assets/1622ae5f-8fac-4934-84cd-f50f3bab21af" />

### After  
<img width="382" height="582" alt="image" src="https://github.com/user-attachments/assets/8adda51a-c815-4ed7-a5bc-c3b35282a83d" />

---
