### PR TITLE
Fix showing stale theme on back/forward navigation (bfcache)

### DIFF
--- a/src/components/ThemeProvider.astro
+++ b/src/components/ThemeProvider.astro
@@ -31,8 +31,12 @@
 	// initial setup
 	setTheme(getUserPref());
 
-	// View Transitions hook to restore theme
-	document.addEventListener("astro:after-swap", () => setTheme(getUserPref()));
+	// listen for pageshow event, browser restored page from bfcache
+	window.addEventListener("pageshow", (e) => {
+		if (e.persisted) {
+			setTheme(getUserPref());
+		}
+	});
 
 	// listen for theme-change custom event, fired in src/components/ThemeToggle.astro
 	document.addEventListener("theme-change", (e) => {


### PR DESCRIPTION
<!-- Thank you for opening a PR and making this theme even better, I appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?

<!-- Delete any that don’t apply -->

- Minor fixes (broken links, typos, css, etc.)

#### Description

- Adds an event listener for back/forward navigation, updates the theme based on user preference