### PR TITLE
Add Deploy to PandaStack button

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ pnpm dlx create-astro --template chrismwilliams/astro-theme-cactus
 ```
 
 [![Deploy with Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/chrismwilliams/astro-theme-cactus) [![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fchrismwilliams%2Fastro-theme-cactus&project-name=astro-theme-cactus)
+[![Deploy to PandaStack](https://dashboard.pandastack.io/deploy-button.svg)](https://dashboard.pandastack.io/deploy?repo=chrismwilliams/astro-theme-cactus&type=static&buildCmd=npm+run+build&outputDir=dist)
 
 ## Preview
 


### PR DESCRIPTION
<img src="https://pandastack.io/logo.png" alt="PandaStack" height="40"/>

## Add Deploy to PandaStack button

This PR adds a **[Deploy to PandaStack](https://pandastack.io)** button alongside the existing Vercel button.

**[PandaStack](https://pandastack.io)** is a cloud deployment platform — supports static sites, containerized apps, databases, cronjobs, and more. A great alternative hosting option for your users.

### What this adds
```
[![Deploy to PandaStack](https://dashboard.pandastack.io/deploy-button.svg)](https://dashboard.pandastack.io/deploy?repo=chrismwilliams/astro-theme-cactus)
```

Happy to adjust build settings or output directory if needed. Feel free to close if you'd prefer to keep one button. 🙂