### PR TITLE
fix: add missing end padding to admonition boxes

### DIFF
--- a/src/styles/components/admonition.css
+++ b/src/styles/components/admonition.css
@@ -1,6 +1,6 @@
 .admonition {
 	--admonition-color: var(--tw-prose-quotes);
-	@apply border-s-2 border-(--admonition-color) py-4 ps-4;
+	@apply border-s-2 border-(--admonition-color) px-4 py-4;
 
 	.admonition-title {
 		@apply my-0! flex items-center gap-2 text-base font-bold text-(--admonition-color) capitalize;

--- a/src/styles/components/admonition.css
+++ b/src/styles/components/admonition.css
@@ -1,6 +1,6 @@
 .admonition {
 	--admonition-color: var(--tw-prose-quotes);
-	@apply border-s-2 border-(--admonition-color) px-4 py-4;
+	@apply border-s-2 border-(--admonition-color) p-4;
 
 	.admonition-title {
 		@apply my-0! flex items-center gap-2 text-base font-bold text-(--admonition-color) capitalize;


### PR DESCRIPTION
## What

Adds horizontal end padding to the `.admonition` container by changing `ps-4` to `px-4`.

## Why

The admonition base rule currently applies `py-4 ps-4` — padding on the block axis and the start side only, with **zero padding on the end side**. Long lines inside an admonition wrap flush against the right edge of the tinted box.

With the default 14px prose it rarely becomes visible because line breaks seldom land exactly at the box edge, but any sufficiently long line (or a slightly larger font size) exposes it. All five admonition types (note / tip / important / caution / warning) share the base rule, so all are affected.

**Before:**

<img width="697" height="216" alt="Screenshot 2026-07-24 at 17 05 02" src="https://github.com/user-attachments/assets/a22540bc-bccb-47b9-9b9b-03ce7880f26b" />

**After:**

<img width="697" height="216" alt="Screenshot 2026-07-24 at 17 05 23" src="https://github.com/user-attachments/assets/66168dd5-881a-4ebe-b6f8-bdae2faf250f" />

## How

One-word change: `ps-4` → `px-4`. The start border and all other styling are untouched, and RTL behavior is preserved since logical properties are kept.

Tested with `pnpm dev` against the markdown-elements demo post — all five admonition variants now have symmetric inline padding.